### PR TITLE
Add tags to resourge group on azure windows action

### DIFF
--- a/pkg/provider/azure/action/windows/windows.go
+++ b/pkg/provider/azure/action/windows/windows.go
@@ -104,6 +104,7 @@ func (r *WindowsRequest) deployer(ctx *pulumi.Context) error {
 		&resources.ResourceGroupArgs{
 			Location:          pulumi.String(r.Location),
 			ResourceGroupName: pulumi.String(qenvsContext.GetID()),
+			Tags:              qenvsContext.GetTags(),
 		})
 	if err != nil {
 		return err


### PR DESCRIPTION
Every resource on the provider should be tagged, recently there was added an option to set custom tags, in addition to them some common ones related to the qenvs run are always added. On that PR the tags were missed on the resource group. This PR add them to the resource group.