### PR TITLE
fix snc host libvirt dependecies for RHEL-9.X

### DIFF
--- a/pkg/provider/aws/modules/compute/services/snc/userdata.tpl
+++ b/pkg/provider/aws/modules/compute/services/snc/userdata.tpl
@@ -5,7 +5,10 @@ rh_subscription:
   auto-attach: true
 packages:
   - podman
-  - "@virt"
+  - qemu-kvm 
+  - libvirt 
+  - virt-install 
+  - virt-viewer
   - jq
   - git
 runcmd:


### PR DESCRIPTION
within new OCP versions it is required to run SNC on a RHEL-9.X based system. For RHEL-9.X there are some libvirt depdencies missing. When cloud-init is trying to install missing dependecies it ends up on error as so the host health checker.